### PR TITLE
Use the same face for defmacro as for defn and the rest

### DIFF
--- a/hy-mode.el
+++ b/hy-mode.el
@@ -63,7 +63,7 @@
                  "is_not" "not-in" "not_in" "+" "%" "/" "//" "*" "**" "<<" ">>"
                  "|" "^" "&" "-" "+=" "/=" "//=" "*=" "-=" "_=" "%=" "**=" "<<="
                  ">>=" "|=" "^=" "&=" "setv" "setf" "def" "car" "first" "cdr" "rest"
-                 "take" "drop" "print"))
+                 "take" "drop" "print" "quasiquote" "unquote" "unquote-splice"))
               "\\)[ \n\r\t)]")
      (1 font-lock-builtin-face))
     ("\\<:[^ \r\n\t]+\\>" 0 font-lock-constant-face)))


### PR DESCRIPTION
As the subject says, this patch makes hy-mode recognise `defmacro`, and highlight it appropriately. Also adds support for `require`, `quasiquote`, `unquote` and `unquote-splice`.
