### PR TITLE
Adding font-lock for function parameters

### DIFF
--- a/hy-mode.el
+++ b/hy-mode.el
@@ -66,7 +66,8 @@
                  "take" "drop" "print" "quasiquote" "unquote" "unquote-splice"))
               "\\)[ \n\r\t)]")
      (1 font-lock-builtin-face))
-    ("\\<:[^ \r\n\t]+\\>" 0 font-lock-constant-face)))
+    ("\\<:[^ \r\n\t]+\\>" 0 font-lock-constant-face)
+    ("\\<&[^ \r\n\t]+\\>" 0 font-lock-type-face)))
 
 (defcustom hy-indent-specform
   '(("for" . 1)


### PR DESCRIPTION
This commit adds font-lock for highlighting function parameters like &optional etc.
Followed the same pattern as used for highlighting keywords.

I'm not sure of what font-lock face to use, so followed the convention used in 
emacs lisp and cl and used font-lock-type-face
