### PR TITLE
Correct highlight of modules in require/import list

### DIFF
--- a/hy-mode.el
+++ b/hy-mode.el
@@ -39,14 +39,22 @@
 
 (defconst hy-font-lock-keywords
   `((,(concat "(\\("
-              (regexp-opt '("defn" "defun" "defclass" "import"
-                            "defmacro" "require" "defmacro/g!"
-                            "defreader"))
+              (regexp-opt '("defn" "defun" "defclass" "defmacro"
+                            "defmacro/g!" "defreader"))
               "\\)\\>"
               ;; Spaces
               "[ \r\n\t]+"
               ;; Function/class name
               "\\([^ \r\n\t()]+\\)")
+     (1 font-lock-keyword-face)
+     (2 font-lock-function-name-face nil t))
+    (,(concat "(\\("
+              (regexp-opt '("require" "import"))
+              "\\)\\>"
+              ;; Spaces
+              "[ \r\n\t]+"
+              ;; module list
+              "\\([^\\[()]+\\)")
      (1 font-lock-keyword-face)
      (2 font-lock-function-name-face nil t))
     (,(concat "(\\("


### PR DESCRIPTION
Currently only the first module is highlighted in require/import lists, this fix highlights all of them. Note that this does not fix highlighting of submodule imports, so

```
;; sys and pprint are now highlighted, os and path are still not highlighted
(import sys pprint [os [path]])
```

These can be arbitrarily nested, so I'm not sure how to go about supporting highlighting in this case.
