### PR TITLE
additional font-locking

### DIFF
--- a/hy-mode.el
+++ b/hy-mode.el
@@ -94,6 +94,7 @@
                  "identity" "yield-from"))
               "\\)[ \n\r\t)]")
      (1 font-lock-builtin-face))
+    ("^#!.*$" 0 font-lock-comment-face)  ; shebang line
     ("\\<:[^ \r\n\t]+\\>" 0 font-lock-constant-face)
     ("\\<&[^ \r\n\t]+\\>" 0 font-lock-type-face)))
 

--- a/hy-mode.el
+++ b/hy-mode.el
@@ -39,15 +39,24 @@
 
 (defconst hy-font-lock-keywords
   `((,(concat "(\\("
-              (regexp-opt '("defn" "defun" "defclass" "defmacro"
-                            "defmacro/g!" "defreader" "defmain"))
+              (regexp-opt '("defn" "defun" "defmacro" "defmacro/g!"
+                            "defreader" "defmain"))
               "\\)\\>"
               ;; Spaces
               "[ \r\n\t]+"
-              ;; Function/class name
+              ;; Function name
               "\\([^ \r\n\t()]+\\)")
      (1 font-lock-keyword-face)
      (2 font-lock-function-name-face nil t))
+    (,(concat "(\\("
+              (regexp-opt '("defclass"))
+              "\\)\\>"
+              ;; Spaces
+              "[ \r\n\t]+"
+              ;; Class name
+              "\\([^][ \r\n\t(){}]+\\)")
+     (1 font-lock-keyword-face)
+     (2 font-lock-type-face))
     (,(concat "(\\("
               (regexp-opt '("require" "import"))
               "\\)\\>"

--- a/hy-mode.el
+++ b/hy-mode.el
@@ -94,6 +94,10 @@
                  "identity" "yield-from"))
               "\\)[ \n\r\t)]")
      (1 font-lock-builtin-face))
+    (,(concat "\\<"
+              (regexp-opt '("true" "True" "false" "False" "nil" "None"))
+              "\\>")
+     (0 font-lock-constant-face))
     ("^#!.*$" 0 font-lock-comment-face)  ; shebang line
     ("\\<:[^ \r\n\t]+\\>" 0 font-lock-constant-face)
     ("\\<&[^ \r\n\t]+\\>" 0 font-lock-type-face)))


### PR DESCRIPTION
Hi (hy?). This pull-request proposes a few additional font-lock keywords:
 * lines starting with `#!` appear in `font-lock-comment-face` to support [shebang lines](https://github.com/hylang/hy/issues/23)
 * booleans and `None` appear in `font-lock-constant-face`
 * class names in class definitions appear in `font-lock-type-face` rather than `-function-name-face`

Preview (Emacs 24.3.1, default color theme):
![hy_additional_font_lock_proposal](https://cloud.githubusercontent.com/assets/1076988/5601327/0ffbe2e6-92ad-11e4-87ae-97b505e143b9.png)

