### PR TITLE
Solve UnicodeEncodeError issue

### DIFF
--- a/hy-mode.el
+++ b/hy-mode.el
@@ -210,7 +210,8 @@ Lisp function does not specify a special indentation."
   (setq-local lisp-indent-function 'hy-indent-function)
   (setq-local inferior-lisp-load-command
 	      (concat "(import [hy.importer [import-file-to-module]])\n"
-		      "(import-file-to-module \"__main__\" \"%s\")\n")))
+		      "(import-file-to-module \"__main__\" \"%s\")\n"))
+  (setenv "PYTHONIOENCODING" "UTF-8"))
 
 (set-keymap-parent hy-mode-map lisp-mode-shared-map)
 (define-key hy-mode-map (kbd "C-M-x")   'lisp-eval-defun)


### PR DESCRIPTION
Hi,

I got a Unicode error(**UnicodeEncodeError: 'utf-8' codec can't encode characters in position 3-8: surrogates not allowed**) when I  wanted to type some unicode word like (print "测试")

Then I googled a result from here: [http://emacs.stackexchange.com/questions/24139/unicodeencodeerror-in-inferior-python-under-windows](http://emacs.stackexchange.com/questions/24139/unicodeencodeerror-in-inferior-python-under-windows)

And it works.

Thanks!