### PR TITLE
Change keybinding for 'hy-shell-start-or-switch-to-shell

### DIFF
--- a/hy-mode.el
+++ b/hy-mode.el
@@ -1530,7 +1530,7 @@ Not all defuns can be argspeced - eg. C defuns.\"
 
 ;; Spacemacs users please see spacemacs-hy, all bindings defined there
 (set-keymap-parent hy-mode-map lisp-mode-shared-map)
-(define-key hy-mode-map (kbd "C-c C-e") 'hy-shell-start-or-switch-to-shell)
+(define-key hy-mode-map (kbd "C-c C-z") 'hy-shell-start-or-switch-to-shell)
 (define-key hy-mode-map (kbd "C-c C-b") 'hy-shell-eval-buffer)
 
 (define-key hy-mode-map (kbd "C-c C-t") 'hy-insert-pdb)


### PR DESCRIPTION
C-c C-e doesn't makes sense! All another Lisps mode as well lisp-mode integrated with slime use C-c C-z.