### PR TITLE
Syntax and macro updates

### DIFF
--- a/hy-mode.el
+++ b/hy-mode.el
@@ -1018,7 +1018,6 @@ CMD defaults to the result of `hy--shell-calculate-command'."
 (defconst hy-eldoc-setup-code
   "(import builtins)
 (import inspect)
-(import [hy.macros [-hy-macros]])
 
 (defn --HYDOC-format-argspec [argspec]
   \"Lispy version of format argspec covering all defun kwords.\"
@@ -1117,7 +1116,7 @@ Not all defuns can be argspeced - eg. C defuns.\"
   \"Get eldoc string for a macro.\"
   (try
     (do (setv obj (.replace obj \"-\" \"_\"))
-        (setv macros (get -hy-macros None))
+        (setv macros (get --macros-- None))
 
         (when (in obj macros)
           (--HYDOC-format-eldoc-string obj (get macros obj) :full full)))
@@ -1274,14 +1273,13 @@ Not all defuns can be argspeced - eg. C defuns.\"
 (try
  (import [hy.lex.parser [hy-symbol-unmangle hy-symbol-mangle]])
  (except [e ImportError]
-         (import [hy.lex.parser [unmangle :as hy-symbol-unmangle
-                                 mangle :as hy-symbol-mangle]])))
+         (import [hy.lex [unmangle :as hy-symbol-unmangle
+                          mangle :as hy-symbol-mangle]])))
 (try
  (import [hy.compiler [-compile-table]])
  (except [e ImportError]
          (import [hy.compiler [-special-form-compilers :as -compile-table]])))
 
-(import [hy.macros [-hy-macros]])
 (import [hy.core.shadow [*]])
 (import [hy.core.language [*]])
 
@@ -1302,10 +1300,9 @@ Not all defuns can be argspeced - eg. C defuns.\"
 
 (defn --HYCOMPANY-get-macros []
   \"Extract macro names from all namespaces and compile-table symbols.\"
-  (->> -hy-macros
-     (.values)
-     (map dict.keys)
-     (chain -compile-table)
+  (->> --macros--
+     (.keys)
+     (chain (.keys -compile-table))
      flatten
      (map --HYCOMPANY-get-name)
      (map hy-symbol-unmangle)
@@ -1372,10 +1369,7 @@ Not all defuns can be argspeced - eg. C defuns.\"
 
 (defn --HYANNOTATE-search-macros [text]
   (setv text (hy-symbol-mangle text))
-  (for [macro-dict (.values -hy-macros)]
-    (when (in text macro-dict)
-      (return (get macro-dict text))))
-  None)
+  (.get --macros-- text None))
 
 (defn --HYANNOTATE [x]
   ;; only builtins format on case basis

--- a/hy-mode.el
+++ b/hy-mode.el
@@ -77,6 +77,7 @@ Keep nil unless using specific Hy branch.")
     :fuzzy
     ("def"
      "with"
+     "let"
      "with/a"
      "fn"
      "fn/a"
@@ -129,16 +130,16 @@ will indent special. Exact forms require the symbol and def exactly match.")
   '("*map" "accumulate" "and" "assoc" "butlast" "calling-module-name" "car"
     "cdr" "chain" "coll?" "combinations" "comp" "complement" "compress" "cons"
     "cons?" "constantly" "count" "cut" "cycle" "dec" "defmain" "del"
-    "dict-comp" "disassemble" "distinct" "doto" "drop" "drop-last" "drop-while"
+    "dfor" "disassemble" "distinct" "doto" "drop" "drop-last" "drop-while"
     "empty?" "even?" "every?" "filter" "first" "flatten" "float?" "fraction"
     "genexpr" "gensym" "get" "group-by" "identity" "inc" "input"
     "instance?" "integer" "integer-char?" "integer?" "interleave" "interpose"
     "is" "is-not" "is_not" "islice" "iterable?" "iterate" "iterator?" "juxt"
-    "keyword" "keyword?" "last" "list*" "list-comp" "macroexpand"
+    "keyword" "keyword?" "last" "list*" "lfor" "macroexpand"
     "macroexpand-1" "map" "merge-with" "multicombinations" "name" "neg?" "none?"
     "nth" "numeric?" "odd?" "or" "partition" "permutations"
     "pos?" "product" "quasiquote" "quote" "range" "read" "read-str"
-    "reduce" "remove" "repeat" "repeatedly" "rest" "second" "setv" "set-comp"
+    "reduce" "remove" "repeat" "repeatedly" "rest" "second" "setv" "sfor"
     "slice" "some" "string" "string?" "symbol?" "take" "take-nth" "take-while"
     "tee" "unquote" "unquote-splice" "xor" "zero?" "zip" "zip-longest"
 
@@ -183,10 +184,9 @@ will indent special. Exact forms require the symbol and def exactly match.")
   "Hy exception keywords.")
 
 (defconst hy--kwds-defs
-  '("defn" "defn/a" "defun"
+  '("defn" "defn/a"
     "defmacro" "defmacro/g!" "defmacro!"
-    "defreader" "defsharp" "deftag"
-    "defmain" "defmulti"
+    "deftag" "defmain" "defmulti"
     "defmethod")
 
   "Hy definition keywords.")
@@ -216,6 +216,7 @@ will indent special. Exact forms require the symbol and def exactly match.")
 
     ;; Functional
     "fn" "fn/a"
+    "await"
     "yield" "yield-from"
     "with" "with*" "with/a" "with/a*"
     "with-gensyms"
@@ -230,10 +231,7 @@ will indent special. Exact forms require the symbol and def exactly match.")
 
     ;; Misc
     "global" "nonlocal"
-    "eval" "eval-and-compile" "eval-when-compile"
-
-    ;; Discontinued in Master
-    "apply" "kwapply")
+    "eval" "eval-and-compile" "eval-when-compile")
 
   "Hy special forms keywords.")
 
@@ -302,18 +300,18 @@ will indent special. Exact forms require the symbol and def exactly match.")
 
 ;;;; Static
 
-(defconst hy--font-lock-kwds-aliases
-  (list
-   (rx (group-n 1 (or "defmacro-alias" "defn-alias" "defun-alias"))
-       (1+ space)
-       "["
-       (group-n 2 (1+ anything))
-       "]")
-
-   '(1 font-lock-keyword-face)
-   '(2 font-lock-function-name-face nil t))
-
-  "Hy aliasing keywords.")
+;; (defconst hy--font-lock-kwds-aliases
+;;   (list
+;;    (rx (group-n 1 (or "defmacro-alias" "defn-alias" "defun-alias"))
+;;        (1+ space)
+;;        "["
+;;        (group-n 2 (1+ anything))
+;;        "]")
+;;
+;;    '(1 font-lock-keyword-face)
+;;    '(2 font-lock-function-name-face nil t))
+;;
+;;   "Hy aliasing keywords.")
 
 (defconst hy--font-lock-kwds-class
   (list
@@ -364,8 +362,8 @@ will indent special. Exact forms require the symbol and def exactly match.")
 (defconst hy--font-lock-kwds-tag-macros
   (list
    (rx "#"
-       (not (any "*" "@" "["))  ; #* is unpacking, #@ decorator, #[ bracket str
-       (0+ word))
+       (not (any "*" "@" "[" ")" space))  ; #* is unpacking, #@ decorator, #[ bracket str
+       (0+ (syntax word)))
 
    '(0 font-lock-function-name-face))
 
@@ -457,7 +455,7 @@ will indent special. Exact forms require the symbol and def exactly match.")
 ;;;; Grouped
 
 (defconst hy-font-lock-kwds
-  (list hy--font-lock-kwds-aliases
+  (list ;hy--font-lock-kwds-aliases
         hy--font-lock-kwds-builtins
         hy--font-lock-kwds-class
         hy--font-lock-kwds-constants

--- a/hy-mode.el
+++ b/hy-mode.el
@@ -727,11 +727,15 @@ a string or comment."
   "Format a PROC-NAME with closing astericks."
   (->> proc-name (s-prepend "*") (s-append "*")))
 
+(defun hy-shell-get-process-name (&optional internal)
+  "Get process name corr. to `hy-shell-buffer-name'/`hy-shell-internal-buffer-name'."
+  (if internal
+      hy-shell-internal-buffer-name
+    hy-shell-buffer-name))
+
 (defun hy-shell-get-process (&optional internal)
   "Get process corr. to `hy-shell-buffer-name'/`hy-shell-internal-buffer-name'."
-  (-> (if internal hy-shell-internal-buffer-name hy-shell-buffer-name)
-     hy--shell-format-process-name
-     get-buffer-process))
+  (get-process (hy-shell-get-process-name internal)))
 
 (defun hy--shell-current-buffer-process ()
   "Get process associated with current buffer."
@@ -995,7 +999,7 @@ Eldoc, Anaconda, and other hy-mode features."))
            nil]
       (prog1
           (-> (hy--shell-calculate-command 'internal)
-             (hy--shell-make-comint hy-shell-internal-buffer-name nil 'internal)
+              (hy--shell-make-comint (hy-shell-get-process-name 'internal) nil 'internal)
              get-buffer-process)
         (hy--shell-send-internal-setup-code)
         (message "Hy internal process successfully started")))))


### PR DESCRIPTION
Just some recent updates.

Otherwise, I would like to move more toward the `python.el` method of handling processes; that way, one can run independent processes based only on processes naming (e.g. per-venv processes with `*Python[my-venv-name]*` named-buffers)