### PR TITLE
Processes managed by name

### DIFF
--- a/hy-mode.el
+++ b/hy-mode.el
@@ -32,7 +32,7 @@
 
 ;;; Code:
 
-(require 'cl)
+(require 'cl-lib)
 (require 'dash)
 (require 'dash-functional)
 (require 's)

--- a/hy-mode.el
+++ b/hy-mode.el
@@ -733,8 +733,10 @@ a string or comment."
     hy-shell-buffer-name))
 
 (defun hy-shell-get-process (&optional internal)
-  "Get process corresponding to `hy-shell-get-process-name'."
-  (get-process (hy-shell-get-process-name internal)))
+  "Get process corresponding to `hy-shell-get-process-name' or the current buffer."
+  (or (get-process (hy-shell-get-process-name internal))
+      (and (derived-mode-p 'inferior-hy-mode)
+           (get-buffer-process (current-buffer)))))
 
 (defun hy-shell-get-or-create-internal-process ()
   "Get or create an internal Hy process."
@@ -742,8 +744,10 @@ a string or comment."
       (run-hy-internal)))
 
 (defun hy--shell-current-buffer-a-process? ()
-  "Is `current-buffer' a live process?"
-  (process-live-p (hy-shell-get-process)))
+  "Is `current-buffer' a live Hy process?"
+  (and (derived-mode-p 'inferior-hy-mode)
+       (get-buffer-process (current-buffer))
+       (process-live-p (current-buffer))))
 
 (defun hy--shell-get-or-create-buffer ()
   "Get or create a buffer for the current hy shell process."
@@ -752,9 +756,11 @@ a string or comment."
            (hy--shell-get-buffer))))
 
 (defun hy--shell-get-buffer (&optional internal)
-  (when-let ((process
-               (hy-shell-get-process internal)))
-    (process-buffer process)))
+  (if (derived-mode-p 'inferior-hy-mode)
+      (current-buffer)
+    (when-let ((process
+                (hy-shell-get-process internal)))
+      (process-buffer process))))
 
 (defun hy--shell-buffer? (&optional internal)
   "Does a Hy shell buffer exist for the current buffer?"

--- a/hy-mode.el
+++ b/hy-mode.el
@@ -1485,7 +1485,7 @@ Not all defuns can be argspeced - eg. C defuns.\"
   (when (and (region-active-p)
              (not (region-noncontiguous-p)))
     (-let [text
-           (buffer-substring (region-beginning) (region-end))]
+           (buffer-substring-no-properties (region-beginning) (region-end))]
       (unless (hy--shell-buffer?)
         (hy-shell-start-or-switch-to-shell))
       (hy--shell-with-shell-buffer

--- a/hy-mode.el
+++ b/hy-mode.el
@@ -332,8 +332,7 @@ will indent special. Exact forms require the symbol and def exactly match.")
         (: symbol-start
            "with-decorator"
            symbol-end
-           (1+ space)))
-    (1+ word))
+           (1+ space))))
 
    '(0 font-lock-type-face))
 

--- a/hy-mode.el
+++ b/hy-mode.el
@@ -849,7 +849,10 @@ Constantly extracts current prompt text and executes and manages applying
    (add-hook 'post-command-hook
              'hy--shell-fontify-prompt-post-command-hook nil 'local)
    (add-hook 'kill-buffer-hook
-             'hy--shell-kill-buffer nil 'local)))
+             (lambda ()
+               (unless (derived-mode-p 'inferior-hy-mode)
+                 (hy--shell-kill-buffer)))
+             nil 'local)))
 
 (defun hy--shell-font-lock-spy-output (string)
   "Applies font-locking to hy outputted python blocks when `--spy' is enabled."

--- a/hy-mode.el
+++ b/hy-mode.el
@@ -186,8 +186,8 @@ will indent special. Exact forms require the symbol and def exactly match.")
 (defconst hy--kwds-defs
   '("defn" "defn/a"
     "defmacro" "defmacro/g!" "defmacro!"
-    "deftag" "defmain" "defmulti"
-    "defmethod")
+    "deftag" "defmain"
+    "defnr" "defmulti" "defmethod")
 
   "Hy definition keywords.")
 


### PR DESCRIPTION
The last commit in this PR enables customized Hy shell buffers/processes, so, now, one can do
```elisp
(flet ((hy-shell-get-process-name (&rest args) "Hy<testing>"))
  (run-hy))
```
and `hy-mode` will create a new, independent `comint` buffer and process using the name `Hy<testing>`.
