### PR TITLE
Add autoloads for {auto,interpreter}-mode-alist

### DIFF
--- a/hy-mode.el
+++ b/hy-mode.el
@@ -277,7 +277,9 @@ commands."
 
 ;;; hy-mode
 
+;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.hy\\'" . hy-mode))
+;;;###autoload
 (add-to-list 'interpreter-mode-alist '("hy" . hy-mode))
 
 ;;;###autoload


### PR DESCRIPTION
If packages are set to deferred loading, such as with `(setq use-package-always-defer t)`, Hy files will never get recognized automatically.