### PR TITLE
prevent company-mode Symbol's value is void errors

### DIFF
--- a/hy-mode.el
+++ b/hy-mode.el
@@ -294,9 +294,10 @@ commands."
     (hy-mode--setup-jedhy)
 
     (hy-mode--support-eldoc)
-    (hy-mode--support-company)
 
-    (add-hook 'inferior-hy-mode-hook #'hy-mode--support-company)))
+    (when (featurep 'company)
+      (hy-mode--support-company)
+      (add-hook 'inferior-hy-mode-hook #'hy-mode--support-company))))
 
 ;;; Bindings
 


### PR DESCRIPTION
Before this fix if company-mode was not loaded then hy-mode would fail
to load because it would not find company-backends and company-grab-symbol.

This commit fixes the issue by checking whether those symbols are bound
before executing code that depends on them.