### PR TITLE
Fix: don't complete when in comment or string

### DIFF
--- a/hy-jedhy.el
+++ b/hy-jedhy.el
@@ -293,7 +293,8 @@ shift-K keybinding that executes `spacemacs/evil-smart-doc-lookup'."
   (when (and (memq major-mode '(hy-mode inferior-hy-mode))
              (hy-shell--live-internal?))
     (cl-case command
-      (prefix (company-grab-symbol))
+      (prefix (unless (company-in-string-or-comment)
+                (company-grab-symbol)))
       (candidates (hy-jedhy--prefix-str->candidates prefix-or-candidate-str))
       (annotation (hy-jedhy--candidate-str->annotation prefix-or-candidate-str))
       (meta (hy-jedhy--candidate-str->eldoc prefix-or-candidate-str)))))


### PR DESCRIPTION
Currently when `company-hy` is asked for a `prefix` it just calls `(company-grab-symbol)`.
If this happens inside the string no meaningful completion can be done and `company-hy` should return `nil`.
This PR adds a check for this with `(company-in-string-or-comment)`, thus giving option to other backbends to do their work.

Most notable this allows file completion via `company-files` inside strings, so
```hy
(pd.read-csv "./") ;; will complete files instead of doing nothing
```