### PR TITLE
Fix indent on immediately applied function definition/evaluation results.

### DIFF
--- a/hy-mode.el
+++ b/hy-mode.el
@@ -57,7 +57,7 @@
   '("when" "unless"
     "for" "for*" "for/a" "for/a*"
     "while"
-    "except" "catch")
+    "except" "catch" "assoc")
   "Symbols that will have following lines indented +1 when matched.
 
 Examples:


### PR DESCRIPTION
I hope you don't mind the unsolicited PR but I made the changes for my own use anyway so thought it makes sense to share.

Current behaviour (installed from master):

```hy
((fn [x y] (+ x y))
  1
 7)

((fn [x y]
   (+ x y))
  1
 7)

(((fn [x] (fn [y] (+ x y)))
   3)
  4)
```

The indentation of the rest of the forms in the outermost expression (1, 7, 3, 4) is currently "one past the opening paren of the previous sexp". This differs from Hy's style guide (see [the third law](https://docs.hylang.org/en/stable/style-guide.html#the-three-laws)) and indentation in other lisp modes (e.g. elisp mode), and to my eye is confusing. This PR changes the behaviour so the previous example will be indented as such:

```hy
((fn [x y] (+ x y))
 1
 7)

((fn [x y]
   (+ x y))
 1
 7)

(((fn [x] (fn [y] (+ x y)))
  3)
 4)
```

I also added `assoc` to `hy-indent--exactly`, to bring behaviour in line with the style guide (see [special arguments](https://docs.hylang.org/en/stable/style-guide.html#special-arguments)).