### PR TITLE
Add longer startup timeout

### DIFF
--- a/README.org
+++ b/README.org
@@ -48,6 +48,8 @@ issues please provide as much details as you can.
 
 Execute tests after running ~cask install~ with the command: ~cask exec buttercup -L .~
 
+For linux users, after installing buttercup (available from melpa), execute the tests from the project root with ~emacs -batch -f package-initialize -L . -f buttercup-run-discover~.
+
 Process-based tests currently rely on setting ~hy-test--pyvenv-name~ to the name
 of a virtual environment containing Hy, see ~hy-test.el~. If not set, then
 a warning will be given and process-based tests will be skipped.

--- a/hy-shell.el
+++ b/hy-shell.el
@@ -51,6 +51,13 @@
 (defvar hy-shell--redirect-timeout 0.5
   "Seconds (float) to allow redirection commands to complete before quitting.")
 
+(defvar hy-shell--startup-timeout 3
+  "Seconds (float) for `accept-process-output' to wait for REPL banner text.
+
+`hy-shell--redirect-check-prompt-regexp' may throw an error if
+`accept-process-output' (called in `hy-shell--make-comint') times
+out before consuming the REPL banner text.")
+
 ;;;; Managed
 
 (defconst hy-shell--name "Hy"
@@ -142,7 +149,7 @@
         (inferior-hy-mode))
 
       ;; Get shell's initial output/prompt
-      (accept-process-output (hy-shell--current-process) 0.5)
+      (accept-process-output (hy-shell--current-process) hy-shell--startup-timeout)
 
       (hy-shell--current-process))))
 


### PR DESCRIPTION
I believe this fixes #85. I was getting the error

```
hy-shell--redirect-check-prompt-regexp: No prompt found or ‘comint-prompt-regexp’ not set properly
```

when running the tests, and when starting the first hy buffer of an emacs session (hy process starting up for jedhy). It may have been occurring at other times, but I did not note the exact circumstances. The was caused by `accept-process-output` timing out before the hy REPL writes its banner text ("hy 0.20.0 ..."). I've added a variable (`hy-shell--startup-timeout`) with a default of 3 seconds, and this seems to fix it for me.
