### PR TITLE
Replace deprecated dash-functional dependency

### DIFF
--- a/Cask
+++ b/Cask
@@ -5,7 +5,6 @@
 
 (depends-on "cl-lib")
 (depends-on "dash")
-(depends-on "dash-functional")
 (depends-on "s")
 
 (development

--- a/hy-base.el
+++ b/hy-base.el
@@ -28,7 +28,6 @@
 
 (require 'cl-lib)
 (require 'dash)
-(require 'dash-functional)
 (require 's)
 
 ;;; Syntax Methods

--- a/hy-mode.el
+++ b/hy-mode.el
@@ -8,7 +8,7 @@
 ;; URL: http://github.com/hylang/hy-mode
 ;; Version: 1.0
 ;; Keywords: languages, lisp, python
-;; Package-Requires: ((dash "2.13.0") (dash-functional "1.2.0") (s "1.11.0") (emacs "24"))
+;; Package-Requires: ((dash "2.18.0") (s "1.11.0") (emacs "24"))
 
 ;; hy-mode is free software; you can redistribute it and/or modify it
 ;; under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Dash 2.18.0 now subsumes `dash-functional`.

See https://github.com/magnars/dash.el/blob/master/NEWS.md#from-217-to-218