### PR TITLE
workaround for hy-1.0a3

### DIFF
--- a/hy-jedhy.el
+++ b/hy-jedhy.el
@@ -62,7 +62,7 @@
   "Text identifying successful startup of jedhy.")
 
 (defconst hy-jedhy--reset-namespace-code
-  "(setv --JEDHY (jedhy.api.API :locals- (locals) :globals- (globals) :macros- --macros--))"
+  "(setv --JEDHY (jedhy.api.API :locals- (locals) :globals- (globals) :macros- __macros__))"
   "Text to send to make Jedhy's namespace current.")
 
 ;;; Startup
@@ -149,13 +149,13 @@ Not bound atm as this is temporary, run via M-x or bind yourself."
 
 (defun hy-jedhy--format-output-tuple (output)
   "Format OUTPUT given as a tuple."
-  (unless (s-equals? "()" output)
+  (unless (s-equals? "(,)" output)
     (->> output
        (s-replace-all '(("'" . "")
-                        (",)" . "")  ; one element list case
-                        ("(" . "")
-                        (")" . "")))
-       (s-split ", "))))  ; comma is a valid token so can't replace it
+                        ("(, \"" . "")  ; one element list case
+                        ("\")" . "")))
+       (s-split "\" \"")
+       )))  ; comma is a valid token so can't replace it
 
 (defun hy-jedhy--format-describe-output (output)
   "Converts escaped newlines to true newlines."


### PR DESCRIPTION
# Overview
For someone who wants to use the most recent hy with jedhy and hy-mode in emacs.
Thanks to the work done by @rinx(https://github.com/ekaschalk/jedhy/pull/2), I made workaround version of jedhy and hy-mode for hy 1.0a3.

# How to apply
You need to update both jedhy and hy-mode to make them work.
## jedhy
(In workaround_for_hy-1.0a3 branch in http://github.com/jethack23/jedhy)
Clone my commit of jedhy and install jedhy with this clone. I used this command at the directory of repository.
```shell
pip install .
```
## hy-mode
Clone my commit of hy-mode and apply change I made to your hy-jedhy.el.
(In workaround_for_hy-1.0a3 branch in http://github.com/jethackl23/hy-mode)
In my case, it was in
```shell
~/.emacs.d/elpa/hy-mode-{version}/hy-jedhy.el
```
You may need to X-x byte-compile-file to replace hy-jedhy.elc