### PR TITLE
Add dash as a symbol constituent

### DIFF
--- a/hy-mode.el
+++ b/hy-mode.el
@@ -42,6 +42,8 @@
 
 ;;; Code:
 
+(defvar paredit-mode)
+
 (require 'hy-base)
 
 (require 'hy-font-lock)
@@ -110,6 +112,12 @@ Examples:
 
     table)
   "The `hy-mode' syntax table.")
+
+(defun hy-paredit-setup ()
+  "Make \"paredit-mode\" play nice with `hy-mode'."
+  (when (>= paredit-version 21)
+    (define-key hy-mode-map "{" #'paredit-open-curly)
+    (define-key hy-mode-map "}" #'paredit-close-curly)))
 
 (defconst inferior-hy-mode-syntax-table (copy-syntax-table hy-mode-syntax-table)
   "`inferior-hy-mode' inherits `hy-mode-syntax-table'.")
@@ -290,6 +298,8 @@ commands."
   (hy-mode--setup-syntax)
 
   (hy-mode--support-smartparens)
+
+  (add-hook 'paredit-mode-hook #'hy-paredit-setup)
 
   (when hy-jedhy--enable?
     (hy-mode--setup-jedhy)

--- a/hy-mode.el
+++ b/hy-mode.el
@@ -102,6 +102,7 @@ Examples:
     (modify-syntax-entry ?\, "_" table)
     (modify-syntax-entry ?\| "_" table)
     (modify-syntax-entry ?\# "_" table)
+    (modify-syntax-entry ?\- "_" table)
 
     ;; Note that @ is a valid symbol token but in almost all usages we would
     ;; rather the symbol for ~@foo to be recognized as foo and not @foo.


### PR DESCRIPTION
The dash isn't part of the lisp-mode-syntax-table, apparently due to it being very old. So `edit-mode` for example will not see `this-thing` as a single syntax entity but `this` and `thing` instead.